### PR TITLE
PLF-7803 : Allow to manage languages with different codes between Crowdin and eXo, and add the case of Indonesian ('in' <> 'id')

### DIFF
--- a/src/main/java/org/exoplatform/crowdin/model/CrowdinTranslation.java
+++ b/src/main/java/org/exoplatform/crowdin/model/CrowdinTranslation.java
@@ -34,9 +34,7 @@ public class CrowdinTranslation extends CrowdinFile {
 
   public CrowdinTranslation(File _file, String _name, String _type, String _project, String _lang, CrowdinFile _master, boolean _shouldBeCleaned) {
     super(_file, _name, _type, _project, _shouldBeCleaned);
-    lang = _lang;
-    if (lang.equals("vn")) lang = "vi";
-    else if (lang.equals("es")) lang = "es-ES";
+    lang = getCrowdinLangFromPlatformLang(_lang);
     lang = encodeLanguageName(lang, true);
     master = _master;
   }
@@ -61,6 +59,42 @@ public class CrowdinTranslation extends CrowdinFile {
     } else {
       return (lang == null || lang.isEmpty()) ? lang : lang.replace("-", "_");
     }
+  }
+
+  /**
+   * Return the right language code for eXo from the language code used by Crowdin
+   * This is useful for some specific case, for example the indonesian language code in Crowdin
+   * is "id" whereas it is "in" in the platform (and Java).
+   * @param lang Language code in Crowdin
+   * @return Language code in platform
+   */
+  public static String getPlatformLangFromCrowdinLang(String lang) {
+    String language = lang;
+    if("id".equals(language)) {
+      language = "in";
+    }
+    return language;
+  }
+
+  /**
+   * Return the right language code for Crowdin from the language code used by eXo
+   * This is useful for some specific case, for example the indonesian language code in Crowdin
+   * is "id" whereas it is "in" in the platform (and Java).
+   * @param lang Language code in platform
+   * @return Language code in Crowdin
+   */
+  public static String getCrowdinLangFromPlatformLang(String lang) {
+    String language = lang;
+    if("es".equals(language)) {
+      // make sure that resources files in eXo with only "_es" are correctly mapped to spanish language in Crowdin (es-ES)
+      language = "es-ES";
+    } else if("vn".equals(language)) {
+      language = "vi";
+    } else if("in".equals(language)) {
+      // Indonesian language code is "id" in Crowdin but "in" in Java and eXo
+      language = "id";
+    }
+    return language;
   }
 
   /**

--- a/src/main/java/org/exoplatform/crowdin/mojo/UpdateSourcesMojo.java
+++ b/src/main/java/org/exoplatform/crowdin/mojo/UpdateSourcesMojo.java
@@ -142,6 +142,8 @@ public class UpdateSourcesMojo extends AbstractCrowdinMojo {
         return;
       }
 
+      locale = CrowdinTranslation.getPlatformLangFromCrowdinLang(locale);
+
       String baseDir = currentProj.getProperty("baseDir");
 
       byte[] buf = new byte[1024];
@@ -160,7 +162,7 @@ public class UpdateSourcesMojo extends AbstractCrowdinMojo {
         zipentryName = zipentryName.replace('/', File.separatorChar);
         zipentryName = zipentryName.replace('\\', File.separatorChar);
         String[] path = zipentryName.split(File.separator);
-        String lang = path[0];
+        String lang = CrowdinTranslation.getPlatformLangFromCrowdinLang(path[0]);
         String crowdinProj = path[1];
         String proj = path[2];
         String fileName = "";


### PR DESCRIPTION
Crowdin does not always use the same language codes than in Java. It is the case for Indonesian. Crowdin uses "id", whereas Java still uses "in" (you can use "id" when initialing a Java Locale but it always returns "in" to keep backward compatibility with all Java versions).
This PR updates the Crowdin maven plugin to convert "id" to "in" when creating i18n files.