### PR TITLE
Process only files related to master file during upload translation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>maven-parent-pom</artifactId>
     <groupId>org.exoplatform</groupId>
-    <version>15</version>
+    <version>17</version>
   </parent>
   <groupId>org.exoplatform.translation.crowdin</groupId>
   <artifactId>crowdin-maven-plugin</artifactId>

--- a/src/main/java/org/exoplatform/crowdin/mojo/AbstractCrowdinMojo.java
+++ b/src/main/java/org/exoplatform/crowdin/mojo/AbstractCrowdinMojo.java
@@ -463,7 +463,7 @@ public abstract class AbstractCrowdinMojo extends AbstractMojo {
     String name = filename;
     int filenameDotIndex = name.lastIndexOf(".");
     if(filenameDotIndex >= 0) {
-      name = name.substring(0, dotIndex);
+      name = name.substring(0, filenameDotIndex);
     }
     int filenameUnderscoreIndex = name.indexOf("_");
     if(filenameUnderscoreIndex >= 0) {

--- a/src/test/java/org/exoplatform/crowdin/mojo/UploadTranslationMojoTest.java
+++ b/src/test/java/org/exoplatform/crowdin/mojo/UploadTranslationMojoTest.java
@@ -1,0 +1,42 @@
+package org.exoplatform.crowdin.mojo;
+
+import org.exoplatform.crowdin.model.CrowdinFile;
+import org.exoplatform.crowdin.model.CrowdinFileFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+public class UploadTranslationMojoTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void shouldInitTranslationsOnlyForFilesRelatedToMasterFile() throws Exception {
+        // Given
+        AbstractCrowdinMojo mojo = Mockito.spy(AbstractCrowdinMojo.class);
+        when(mojo.getLanguages()).thenReturn(Arrays.asList("en", "fr", "de"));
+        when(mojo.getFactory()).thenReturn(new CrowdinFileFactory(mojo));
+        doNothing().when(mojo).prepareAndUploadTranslation(anyString(), any(CrowdinFile.class), any(File.class), anyBoolean());
+
+        File file = folder.newFile("test_en.properties");
+        folder.newFile("test_fr.properties");
+        folder.newFile("test_de.properties");
+        folder.newFile("other_en.properties");
+        folder.newFile("other_fr.properties");
+        CrowdinFile master = new CrowdinFile(file, "test_en.properties", "properties", "social", false);
+
+        // When
+        mojo.initTranslations(master);
+
+        // Then
+        // only files related to the master file ("test") must be processed, not others, even if they are in the same folder
+        verify(mojo, times(3)).prepareAndUploadTranslation(anyString(), any(CrowdinFile.class), any(File.class), anyBoolean());
+    }
+}


### PR DESCRIPTION
When initializing a translation file, the process looped over all files in the directory of the master file. If there were others files than the ones related to the given master file, they were processed as well.
This fix allows to only process translation files related to the given master file.