### PR TITLE
Fix Crodinw problem when the properties file is not in a subfolder

### DIFF
--- a/src/main/java/org/exoplatform/crowdin/mojo/UpdateSourcesMojo.java
+++ b/src/main/java/org/exoplatform/crowdin/mojo/UpdateSourcesMojo.java
@@ -163,10 +163,16 @@ public class UpdateSourcesMojo extends AbstractCrowdinMojo {
         zipentryName = zipentryName.replace('\\', File.separatorChar);
         String[] path = zipentryName.split(File.separator);
         String lang = CrowdinTranslation.getPlatformLangFromCrowdinLang(path[0]);
-        String crowdinProj = path[1];
-        String proj = path[2];
         String fileName = "";
-        String cp = crowdinProj + File.separator + proj + File.separator;
+        String cp = "";
+        String proj="";
+        for (int i=1;i<path.length;i++) {
+          cp += path[i] + File.separator;
+          if (i==path.length-1) {
+            proj=path[i];
+          }
+        }
+        getLog().debug("cp : " + cp);
 
         // process only the languages specified
         if (!(lang.equalsIgnoreCase(locale))) {


### PR DESCRIPTION
Before this fix, when a property file is localed at the root level of the zip translation file, an erro occurs when processing zip files : java.lang.ArrayIndexOutOfBoundsException: 2
	at org.exoplatform.crowdin.mojo.UpdateSourcesMojo.applyTranslations(UpdateSourcesMojo.java:167)

In this case, as there is no crowdin project folder, the split cannot find the 3 objects.

This fix make the path building more intelligent by allowing to have a file at root level