### PR TITLE
fix: remove workaround and get correct Indonesian language code - EXO-66238

### DIFF
--- a/src/main/java/org/exoplatform/crowdin/model/CrowdinTranslation.java
+++ b/src/main/java/org/exoplatform/crowdin/model/CrowdinTranslation.java
@@ -62,21 +62,6 @@ public class CrowdinTranslation extends CrowdinFile {
   }
 
   /**
-   * Return the right language code for eXo from the language code used by Crowdin
-   * This is useful for some specific case, for example the indonesian language code in Crowdin
-   * is "id" whereas it is "in" in the platform (and Java).
-   * @param lang Language code in Crowdin
-   * @return Language code in platform
-   */
-  public static String getPlatformLangFromCrowdinLang(String lang) {
-    String language = lang;
-    if("id".equals(language)) {
-      language = "in";
-    }
-    return language;
-  }
-
-  /**
    * Return the right language code for Crowdin from the language code used by eXo
    * This is useful for some specific case, for example the indonesian language code in Crowdin
    * is "id" whereas it is "in" in the platform (and Java).

--- a/src/main/java/org/exoplatform/crowdin/mojo/UpdateSourcesMojo.java
+++ b/src/main/java/org/exoplatform/crowdin/mojo/UpdateSourcesMojo.java
@@ -142,8 +142,6 @@ public class UpdateSourcesMojo extends AbstractCrowdinMojo {
         return;
       }
 
-      locale = CrowdinTranslation.getPlatformLangFromCrowdinLang(locale);
-
       String baseDir = currentProj.getProperty("baseDir");
 
       byte[] buf = new byte[1024];
@@ -162,7 +160,7 @@ public class UpdateSourcesMojo extends AbstractCrowdinMojo {
         zipentryName = zipentryName.replace('/', File.separatorChar);
         zipentryName = zipentryName.replace('\\', File.separatorChar);
         String[] path = zipentryName.split(File.separator);
-        String lang = CrowdinTranslation.getPlatformLangFromCrowdinLang(path[0]);
+        String lang = path[0];
         String fileName = "";
         String cp = "";
         String proj="";


### PR DESCRIPTION
This fix removes an old workaround that was replacing Indonesian new lang code **id** with the old code **in**